### PR TITLE
Add PBaas/Merged Mining Support

### DIFF
--- a/equi/equi-stratum.cpp
+++ b/equi/equi-stratum.cpp
@@ -254,6 +254,11 @@ bool equi_stratum_submit(struct pool_infos *pool, struct work *work)
 	}
 	cbin2hex(solhex, (const char*) work->extra, 1347);
 
+    char* solHexRestore = (char*) calloc(128, 1);
+	cbin2hex(solHexRestore, (const char*)&work->solution[8], 64);
+    memcpy(&solhex[6+16], solHexRestore, 128);
+
+
 	jobid = work->job_id + 8;
 	sprintf(timehex, "%08x", swab32(work->data[25]));
 

--- a/equi/equi-stratum.cpp
+++ b/equi/equi-stratum.cpp
@@ -255,7 +255,7 @@ bool equi_stratum_submit(struct pool_infos *pool, struct work *work)
 	cbin2hex(solhex, (const char*) work->extra, 1347);
 
     char* solHexRestore = (char*) calloc(128, 1);
-	cbin2hex(solHexRestore, (const char*)&work->solution[8], 64);
+    cbin2hex(solHexRestore, (const char*)&work->solution[8], 64);
     memcpy(&solhex[6+16], solHexRestore, 128);
 
 
@@ -267,6 +267,7 @@ bool equi_stratum_submit(struct pool_infos *pool, struct work *work)
 		pool->user, jobid, timehex, noncestr, solhex,
 		stratum.job.shares_count + 10);
 
+	free(solHexRestore);
 	free(solhex);
 	free(noncestr);
 

--- a/verus/verusscan.cpp
+++ b/verus/verusscan.cpp
@@ -180,7 +180,7 @@ extern "C" int scanhash_verus(int thr_id, struct work *work, uint32_t max_nonce,
 	memcpy(sol_data + 3, work->solution, 1344);
 	int version = work->solution[0];
 
-	if (version >= 7) {
+    if (version >= 7) {
         // clear non-canonical data from header/solution before hashing; required for merged mining
         memset(full_data + 4, 0, 96);                        // hashPrevBlock, hashMerkleRoot, hashFinalSaplingRoot
         memset(full_data + 4 + 32 + 32 + 32 + 4, 0, 4);      // nBits

--- a/verus/verusscan.cpp
+++ b/verus/verusscan.cpp
@@ -181,9 +181,13 @@ extern "C" int scanhash_verus(int thr_id, struct work *work, uint32_t max_nonce,
 	int version = work->solution[0];
 
 	if (version >= 7) {
+        // clear non-canonical data from header/solution before hashing; required for merged mining
+        memset(full_data + 4, 0, 96);                        // hashPrevBlock, hashMerkleRoot, hashFinalSaplingRoot
+        memset(full_data + 4 + 32 + 32 + 32 + 4, 0, 4);      // nBits
+        memset(full_data + 4 + 32 + 32 + 32 + 4 + 4, 0, 32); // nNonce
+        memset(sol_data+3+ 8, 0, 64);                        // hashPrevMMRRoot, hashBlockMMRRoot
+    }
 
-
-	}
 	uint32_t  vhash[8] = { 0 };
 
 	VerusHashHalf(blockhash_half, (unsigned char*)full_data, 1487);


### PR DESCRIPTION
Add support for PBaaS/Merged Mining activation

Has issue with duplicate shares remaining to solve:
 - Some bits still being used in block header nonce and need to be moved to end of solution.
 - The nonce assigned by pool needs to be put into end of solution.
 - Any thread/gpu id's need to be put into end of solution.  
----
***PBaaS Activation Notes:***
----
 - Pools should assign/reserve no more than 4 bytes for nonce.
 - Miner should use no more than 8 bytes for its nonce.
 - This leave 3 bytes available for intermediate services such as proxies to use.
 -  Block header nonce can no longer be manipulated by miners
 - Miners are allowed to manipulate last 15 bytes of the solution data ***ONLY***

