### PR TITLE
Better organize last 15 bytes of solution

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -1970,8 +1970,8 @@ static void *miner_thread(void *userdata)
 			nonceptr[0]++; //??
 
 		if (opt_algo == ALGO_EQUIHASH) {
-			nonceptr[1] = (rand()*4);
-			nonceptr[2] |= thr_id;  //try  was nonceptr[1] |= thr_id << 24 monkins edit
+		    //nonceptr[1] = (rand()*4);
+			nonceptr[2] |= ( thr_id ) + ((rand()*4) << 24);  //try  was nonceptr[1] |= thr_id << 24 monkins edit
 			//applog_hex(&work.data[27], 32);
 		} 
 

--- a/verus/verusscan.cpp
+++ b/verus/verusscan.cpp
@@ -188,9 +188,9 @@ extern "C" int scanhash_verus(int thr_id, struct work *work, uint32_t max_nonce,
         memset(full_data + 4 + 32 + 32 + 32 + 4, 0, 4);      // nBits
         memset(full_data + 4 + 32 + 32 + 32 + 4 + 4, 0, 32); // nNonce
         memset(sol_data + 3 + 8, 0, 64);                     // hashPrevMMRRoot, hashBlockMMRRoot
-		memcpy(nonceSpace, &pdata[EQNONCE_OFFSET - 3], 4 );			// transfer the nonce values that would be in the header to
-		memcpy(nonceSpace + 4, &pdata[EQNONCE_OFFSET + 1], 4 );		// the 15 bytes available
-		memcpy(nonceSpace + 8, &pdata[EQNONCE_OFFSET + 2], 1 );	
+		memcpy(nonceSpace, &pdata[EQNONCE_OFFSET - 3], 7 );			// transfer the nonce values that would be in the header to
+//		memcpy(nonceSpace + 4, &pdata[EQNONCE_OFFSET + 1], 3 );		// the 15 bytes available
+		memcpy(nonceSpace + 7, &pdata[EQNONCE_OFFSET + 2], 4 );	
 	}
 
 	uint32_t  vhash[8] = { 0 };


### PR DESCRIPTION
Add support for pools/proxies that use up to 7 bytes of the nonce.
Move thread id, random and hashing nonce to last 8 bytes of solution.

```
380001c1092a00 01 0000a0 b216b202
```
pool nonce1 (up to 7 bytes), thread id byte, random 3 bytes, hashing nonce 4 bytes

