### PR TITLE
Fix client.reconnect

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -93,6 +93,7 @@ bool want_longpoll = false;
 bool have_longpoll = false;
 bool want_stratum = true;
 bool have_stratum = false;
+bool opt_redirect = true;
 bool allow_gbt = true;
 bool allow_mininginfo = true;
 bool check_dups = false; //false;
@@ -336,6 +337,7 @@ Options:\n\
       --no-gbt          disable getblocktemplate support (height check in solo)\n\
       --no-longpoll     disable X-Long-Polling support\n\
       --no-stratum      disable X-Stratum support\n\
+      --no-redirect     ignore requests to change the URL of the mining server\n\
       --no-extranonce   disable extranonce subscribe on stratum\n\
   -q, --quiet           disable per-thread hashmeter output\n\
       --no-color        disable colored output\n\
@@ -428,6 +430,7 @@ struct option options[] = {
 	{ "resume-diff", 1, NULL, 1063 },
 	{ "resume-rate", 1, NULL, 1064 },
 	{ "resume-temp", 1, NULL, 1065 },
+	{ "no-redirect", 0, NULL, 1066 },
 	{ "pass", 1, NULL, 'p' },
 	{ "pool-name", 1, NULL, 1100 },     // pool
 	{ "pool-algo", 1, NULL, 1101 },     // pool
@@ -3197,6 +3200,9 @@ void parse_arg(int key, char *arg)
 	case 1065: // resume-temp
 		d = atof(arg);
 		opt_resume_temp = d;
+		break;
+	case 1066: // no-redirect
+		opt_redirect = false;
 		break;
 	case 'd': // --device
 		{

--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -2606,7 +2606,7 @@ wait_stratum_url:
 			pthread_mutex_unlock(&g_work_lock);
 			restart_threads();
 
-			if (!stratum_connect(&stratum, pool->url) ||
+			if (!stratum_connect(&stratum, stratum.url) ||
 			    !stratum_subscribe(&stratum) ||
 			    !stratum_authorize(&stratum, pool->user, pool->pass))
 			{

--- a/miner.h
+++ b/miner.h
@@ -411,6 +411,7 @@ extern bool want_longpoll;
 extern bool have_longpoll;
 extern bool want_stratum;
 extern bool have_stratum;
+extern bool opt_redirect;
 extern bool opt_stratum_stats;
 extern char *opt_cert;
 extern char *opt_proxy;

--- a/util.cpp
+++ b/util.cpp
@@ -1583,6 +1583,7 @@ static bool stratum_set_difficulty(struct stratum_ctx *sctx, json_t *params)
 static bool stratum_reconnect(struct stratum_ctx *sctx, json_t *params)
 {
 	json_t *port_val;
+    char *url;
 	const char *host;
 	int port;
 
@@ -1594,13 +1595,20 @@ static bool stratum_reconnect(struct stratum_ctx *sctx, json_t *params)
 		port = (int) json_integer_value(port_val);
 	if (!host || !port)
 		return false;
-	
+
+	url = (char*)malloc(32 + strlen(host));
+	sprintf(url, "stratum+tcp://%s:%d", host, port);
+
+	if (!opt_redirect) {
+		applog(LOG_INFO, "Ignoring request to reconnect to %s", url);
+		free(url);
+		return true;
+	}
+
+	applog(LOG_NOTICE, "Server requested reconnection to %s", url);
+
 	free(sctx->url);
-	sctx->url = (char*)malloc(32 + strlen(host));
-	sprintf(sctx->url, "stratum+tcp://%s:%d", host, port);
-
-	applog(LOG_NOTICE, "Server requested reconnection to %s", sctx->url);
-
+	sctx->url =  url;
 	stratum_disconnect(sctx);
 
 	return true;


### PR DESCRIPTION
Fix ccminer to support method [client.reconnect](https://en.bitcoin.it/wiki/Stratum_mining_protocol#client.reconnect) in similar way like [cpuminer-pooler](https://github.com/pooler/cpuminer)

[details](https://github.com/PSLLSP/ccminer/issues/1)